### PR TITLE
Added emscripten support for web builds

### DIFF
--- a/lua-5.3.3/CMakeLists.txt
+++ b/lua-5.3.3/CMakeLists.txt
@@ -36,5 +36,8 @@ set(LUA_LIB_SRCS
 set(LUA_LIB_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 add_library(lua_static STATIC ${LUA_LIB_SRCS})
 target_include_directories(lua_static PUBLIC ${LUA_LIB_INCLUDE})
-target_compile_definitions(lua_static PUBLIC LUA_USE_POSIX)
-
+set(LUA_DEFINITIONS LUA_USE_POSIX)
+if(EMSCRIPTEN)
+    unset(LUA_DEFINITIONS)
+endif()
+target_compile_definitions(lua_static PUBLIC ${LUA_DEFINITIONS})


### PR DESCRIPTION
Walter,
I really liked your repo as it was the easiest way to integrate Lua 5.3+ into my cmake based project.
This  change adds support for Emscripten to run Lua on the web easily.
There's no unit tests here but in my own project I'm fully exercising even lua coroutines in-browser and it's very pleasing.
Feel free to ignore this but others might find this of use.