### PR TITLE
Support dynamic library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,13 @@ project(lua LANGUAGES C VERSION 5.4.4)
 
 option(LUA_SUPPORT_DL "Support dynamic loading of compiled modules" OFF)
 option(LUA_BUILD_AS_CXX "Build lua as C++" OFF)
+option(LUA_ENABLE_SHARED "Build dynamic liblua" ON)
+option(LUA_ENABLE_STATIC "Build static liblua" ON)
 enable_language(CXX)
+
+if(NOT LUA_ENABLE_SHARED AND NOT LUA_ENABLE_STATIC)
+    message(FATAL_ERROR "You must enable at least one of static or dynamic version of liblua")
+endif()
 
 if(${PROJECT_NAME} STREQUAL ${CMAKE_PROJECT_NAME})
     set(TOP_LEVEL TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,7 @@ project(lua LANGUAGES C VERSION 5.4.4)
 option(LUA_SUPPORT_DL "Support dynamic loading of compiled modules" OFF)
 option(LUA_BUILD_AS_CXX "Build lua as C++" OFF)
 option(LUA_ENABLE_SHARED "Build dynamic liblua" ON)
-option(LUA_ENABLE_STATIC "Build static liblua" ON)
 enable_language(CXX)
-
-if(NOT LUA_ENABLE_SHARED AND NOT LUA_ENABLE_STATIC)
-    message(FATAL_ERROR "You must enable at least one of static or dynamic version of liblua")
-endif()
 
 if(${PROJECT_NAME} STREQUAL ${CMAKE_PROJECT_NAME})
     set(TOP_LEVEL TRUE)

--- a/lua-5.4.4/CMakeLists.txt
+++ b/lua-5.4.4/CMakeLists.txt
@@ -33,18 +33,48 @@ set(LUA_LIB_SRCS
     "src/linit.c"
 )
 
+set(TARGETS_TO_INSTALL lua_obj)
+
 if(LUA_BUILD_AS_CXX)
 	set_source_files_properties(${LUA_LIB_SRCS} "src/lua.c" "src/luac.c" PROPERTIES LANGUAGE CXX )
 endif()
 
 add_library(lua_obj OBJECT ${LUA_LIB_SRCS})
 
-add_library(lua_lib)
-target_link_libraries(lua_lib PRIVATE lua_obj)
-set_target_properties(lua_lib PROPERTIES
-    OUTPUT_NAME "lua"
-    VERSION "${PACKAGE_VERSION}"
-)
+if(LUA_ENABLE_SHARED)
+    add_library(lua_dynamic SHARED)
+    target_link_libraries(lua_dynamic PUBLIC lua_obj)
+    set_target_properties(lua_dynamic PROPERTIES
+        VERSION "${PACKAGE_VERSION}"
+    )
+    list(APPEND TARGETS_TO_INSTALL lua_dynamic)
+    if(BUILD_SHARED_LIBS)
+        set(LUA_EXPORT_LIBRARY lua_dynamic)
+        add_library(Lua::Lib ALIAS lua_dynamic)
+    elseif(NOT TOP_LEVEL)
+        set_target_properties(lua_dynamic PROPERTIES
+            EXCLUDE_FROM_ALL ON
+        )
+    endif()
+endif()
+
+if(LUA_ENABLE_STATIC)
+    add_library(lua_static STATIC)
+    target_link_libraries(lua_static PUBLIC lua_obj)
+    set_target_properties(lua_static PROPERTIES
+        VERSION "${PACKAGE_VERSION}"
+    )
+    list(APPEND TARGETS_TO_INSTALL lua_static)
+    if(NOT BUILD_SHARED_LIBS)
+        set(LUA_EXPORT_LIBRARY lua_static)
+        add_library(Lua::Lib ALIAS lua_static)
+    elseif(NOT TOP_LEVEL)
+        set_target_properties(lua_static PROPERTIES
+            EXCLUDE_FROM_ALL ON
+        )
+    endif()
+endif()
+
 
 target_include_directories(lua_obj PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -76,13 +106,11 @@ if(UNIX)
 	)
 endif()
 
-if (WIN32 AND BUILD_SHARED_LIBS)
+if (WIN32)
     target_compile_definitions(lua_obj 
 		PRIVATE LUA_BUILD_AS_DLL
 	)
 endif()
-
-set(TARGETS_TO_INSTALL lua_lib)
 
 if(LUA_BUILD_BINARY)
     include(CheckIncludeFile)
@@ -90,6 +118,7 @@ if(LUA_BUILD_BINARY)
 
 
     add_executable(lua "src/lua.c")
+    # Can not use lua_dynamic because some symbols are not exported
     target_link_libraries(lua PRIVATE lua_obj)
     set_target_properties(lua PROPERTIES 
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
@@ -127,6 +156,7 @@ write_basic_package_version_file(
 install(EXPORT LuaTargets
         FILE LuaTargets.cmake
         DESTINATION "lib/cmake"
+        NAMESPACE Lua::
 )
 
 configure_package_config_file(

--- a/lua-5.4.4/CMakeLists.txt
+++ b/lua-5.4.4/CMakeLists.txt
@@ -37,12 +37,16 @@ if(LUA_BUILD_AS_CXX)
 	set_source_files_properties(${LUA_LIB_SRCS} "src/lua.c" "src/luac.c" PROPERTIES LANGUAGE CXX )
 endif()
 
-add_library(lua_static STATIC ${LUA_LIB_SRCS})
-set_target_properties(lua_static PROPERTIES
+add_library(lua_obj OBJECT ${LUA_LIB_SRCS})
+
+add_library(lua_lib)
+target_link_libraries(lua_lib PRIVATE lua_obj)
+set_target_properties(lua_lib PROPERTIES
     OUTPUT_NAME "lua"
     VERSION "${PACKAGE_VERSION}"
 )
-target_include_directories(lua_static PUBLIC
+
+target_include_directories(lua_obj PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
@@ -55,22 +59,30 @@ if(UNIX)
         if(NOT LIBM)
             message(FATAL_ERROR "libm not found and is required by lua")
         endif()
-        target_link_libraries(lua_static INTERFACE m)
+        target_link_libraries(lua_obj INTERFACE m)
 
         list(APPEND LUA_DEFINITIONS LUA_USE_POSIX)
         if(LUA_SUPPORT_DL)
-            target_compile_definitions(lua_static PRIVATE "LUA_USE_DLOPEN")
-            target_link_libraries(lua_static INTERFACE dl)
+            target_compile_definitions(lua_obj PRIVATE "LUA_USE_DLOPEN")
+            target_link_libraries(lua_obj INTERFACE dl)
         endif()
     endif()
 
-	target_compile_definitions(lua_static 
+	target_compile_definitions(lua_obj 
 		PUBLIC ${LUA_DEFINITIONS}
 	)
-	target_compile_options(lua_static
+	target_compile_options(lua_obj
 		PRIVATE "-Wall" "-Wextra"
 	)
 endif()
+
+if (WIN32 AND BUILD_SHARED_LIBS)
+    target_compile_definitions(lua_obj 
+		PRIVATE LUA_BUILD_AS_DLL
+	)
+endif()
+
+set(TARGETS_TO_INSTALL lua_lib)
 
 if(LUA_BUILD_BINARY)
     include(CheckIncludeFile)
@@ -78,28 +90,28 @@ if(LUA_BUILD_BINARY)
 
 
     add_executable(lua "src/lua.c")
-    target_link_libraries(lua PUBLIC lua_static)
+    target_link_libraries(lua PRIVATE lua_obj)
     set_target_properties(lua PROPERTIES 
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
     )
     if (HAVE_READLINE_READLINE_H)
-        target_compile_definitions(lua PUBLIC "LUA_USE_READLINE")
+        target_compile_definitions(lua PRIVATE "LUA_USE_READLINE")
         target_link_libraries(lua PUBLIC readline)
     endif()
+    list(APPEND TARGETS_TO_INSTALL lua)
 endif()
 
 if(LUA_BUILD_COMPILER)
     add_executable(luac "src/luac.c")
-    target_link_libraries(luac PUBLIC lua_static)
+    target_link_libraries(luac PRIVATE lua_obj)
     set_target_properties(luac PROPERTIES 
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
     )
+    list(APPEND TARGETS_TO_INSTALL luac)
 endif()
 
-install(TARGETS lua_static
+install(TARGETS ${TARGETS_TO_INSTALL}
         EXPORT LuaTargets
-        ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include
 )
 
 install(DIRECTORY include/ TYPE INCLUDE)

--- a/lua-5.4.4/CMakeLists.txt
+++ b/lua-5.4.4/CMakeLists.txt
@@ -33,82 +33,77 @@ set(LUA_LIB_SRCS
     "src/linit.c"
 )
 
-set(TARGETS_TO_INSTALL lua_obj)
+set(TARGETS_TO_INSTALL lua_internal lua_include)
 
 if(LUA_BUILD_AS_CXX)
 	set_source_files_properties(${LUA_LIB_SRCS} "src/lua.c" "src/luac.c" PROPERTIES LANGUAGE CXX )
 endif()
 
-add_library(lua_obj OBJECT ${LUA_LIB_SRCS})
+add_library(lua_internal INTERFACE)
 
-if(LUA_ENABLE_SHARED)
-    add_library(lua_dynamic SHARED)
-    target_link_libraries(lua_dynamic PUBLIC lua_obj)
-    set_target_properties(lua_dynamic PROPERTIES
-        VERSION "${PACKAGE_VERSION}"
-    )
-    list(APPEND TARGETS_TO_INSTALL lua_dynamic)
-    if(BUILD_SHARED_LIBS)
-        set(LUA_EXPORT_LIBRARY lua_dynamic)
-        add_library(Lua::Lib ALIAS lua_dynamic)
-    elseif(NOT TOP_LEVEL)
-        set_target_properties(lua_dynamic PROPERTIES
-            EXCLUDE_FROM_ALL ON
-        )
-    endif()
-endif()
+add_library(lua_include INTERFACE)
 
-if(LUA_ENABLE_STATIC)
-    add_library(lua_static STATIC)
-    target_link_libraries(lua_static PUBLIC lua_obj)
-    set_target_properties(lua_static PROPERTIES
-        VERSION "${PACKAGE_VERSION}"
-    )
-    list(APPEND TARGETS_TO_INSTALL lua_static)
-    if(NOT BUILD_SHARED_LIBS)
-        set(LUA_EXPORT_LIBRARY lua_static)
-        add_library(Lua::Lib ALIAS lua_static)
-    elseif(NOT TOP_LEVEL)
-        set_target_properties(lua_static PROPERTIES
-            EXCLUDE_FROM_ALL ON
-        )
-    endif()
-endif()
-
-
-target_include_directories(lua_obj PUBLIC
+target_include_directories(lua_include INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+
+target_link_libraries(lua_internal INTERFACE lua_include)
+
+if(LUA_ENABLE_SHARED)
+    add_library(lua_shared SHARED ${LUA_LIB_SRCS})
+    target_link_libraries(lua_shared PRIVATE lua_internal PUBLIC lua_include)
+    set_target_properties(lua_shared PROPERTIES
+        VERSION "${PACKAGE_VERSION}"
+    )
+    if(WIN32)
+        target_compile_definitions(lua_shared PRIVATE LUA_BUILD_AS_DLL)
+    endif()
+    list(APPEND TARGETS_TO_INSTALL lua_shared)
+    if(BUILD_SHARED_LIBS)
+        add_library(Lua::Library ALIAS lua_shared)
+    elseif(NOT TOP_LEVEL)
+        set_target_properties(lua_shared PROPERTIES
+            EXCLUDE_FROM_ALL ON
+        )
+    endif()
+endif()
+
+add_library(lua_static STATIC ${LUA_LIB_SRCS})
+target_link_libraries(lua_static PRIVATE lua_internal PUBLIC lua_include)
+set_target_properties(lua_static PROPERTIES
+    VERSION "${PACKAGE_VERSION}"
+)
+list(APPEND TARGETS_TO_INSTALL lua_static)
+if(NOT BUILD_SHARED_LIBS OR NOT LUA_ENABLE_SHARED)
+    add_library(Lua::Library ALIAS lua_static)
+endif()
+
+
 if(UNIX)
-	set(LUA_DEFINITIONS)
-    
     if(NOT EMSCRIPTEN)
         find_library(LIBM m)
         #TODO: Redo this with find_package
         if(NOT LIBM)
             message(FATAL_ERROR "libm not found and is required by lua")
         endif()
-        target_link_libraries(lua_obj INTERFACE m)
+        target_link_libraries(lua_internal INTERFACE m)
 
-        list(APPEND LUA_DEFINITIONS LUA_USE_POSIX)
+        target_compile_definitions(lua_internal 
+            INTERFACE LUA_USE_POSIX
+        )
         if(LUA_SUPPORT_DL)
-            target_compile_definitions(lua_obj PRIVATE "LUA_USE_DLOPEN")
-            target_link_libraries(lua_obj INTERFACE dl)
+            target_compile_definitions(lua_internal INTERFACE "LUA_USE_DLOPEN")
+            target_link_libraries(lua_internal INTERFACE dl)
         endif()
     endif()
 
-	target_compile_definitions(lua_obj 
-		PUBLIC ${LUA_DEFINITIONS}
+	target_compile_options(lua_internal
+		INTERFACE "-Wall" "-Wextra"
 	)
-	target_compile_options(lua_obj
-		PRIVATE "-Wall" "-Wextra"
-	)
-endif()
-
-if (WIN32)
-    target_compile_definitions(lua_obj 
-		PRIVATE LUA_BUILD_AS_DLL
+elseif(Win32)
+    target_compile_options(lua_internal
+		INTERFACE "/Wall"
 	)
 endif()
 
@@ -116,10 +111,9 @@ if(LUA_BUILD_BINARY)
     include(CheckIncludeFile)
     CHECK_INCLUDE_FILE("readline/readline.h" HAVE_READLINE_READLINE_H)
 
-
     add_executable(lua "src/lua.c")
-    # Can not use lua_dynamic because some symbols are not exported
-    target_link_libraries(lua PRIVATE lua_obj)
+    # Can not use lua_shared because some symbols are not exported
+    target_link_libraries(lua PRIVATE lua_static)
     set_target_properties(lua PROPERTIES 
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
     )
@@ -132,7 +126,7 @@ endif()
 
 if(LUA_BUILD_COMPILER)
     add_executable(luac "src/luac.c")
-    target_link_libraries(luac PRIVATE lua_obj)
+    target_link_libraries(luac PRIVATE lua_static)
     set_target_properties(luac PROPERTIES 
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
     )
@@ -147,6 +141,7 @@ install(DIRECTORY include/ TYPE INCLUDE)
 
 include(CMakePackageConfigHelpers)
 
+get_target_property(LUA_EXPORT_LIBRARY Lua::Library ALIASED_TARGET)
 write_basic_package_version_file(
     LuaConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}

--- a/lua-5.4.4/LuaConfig.cmake.in
+++ b/lua-5.4.4/LuaConfig.cmake.in
@@ -3,7 +3,7 @@
 include("${CMAKE_CURRENT_LIST_DIR}/LuaTargets.cmake")
 
 set_and_check(LUA_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
-add_library(Lua::Lib ALIAS "Lua::@LUA_EXPORT_LIBRARY@")
-set(LUA_LIBRARIES "Lua::Lib")
+add_library(Lua::Library ALIAS "Lua::@LUA_EXPORT_LIBRARY@")
+set(LUA_LIBRARIES "Lua::Library")
 
 check_required_components(Lua)

--- a/lua-5.4.4/LuaConfig.cmake.in
+++ b/lua-5.4.4/LuaConfig.cmake.in
@@ -3,8 +3,7 @@
 include("${CMAKE_CURRENT_LIST_DIR}/LuaTargets.cmake")
 
 set_and_check(LUA_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
-set_and_check(LUA_LIBRARY "${PACKAGE_PREFIX_DIR}/lib/liblua.a")
-set(LUA_LIBRARIES "${LUA_LIBRARY}")
-add_library(Lua::Library ALIAS lua_static)
+add_library(Lua::Lib ALIAS "Lua::@LUA_EXPORT_LIBRARY@")
+set(LUA_LIBRARIES "Lua::Lib")
 
 check_required_components(Lua)


### PR DESCRIPTION
By omitting `STATIC` in `add_library`, user can build either static or dynamic library on their discretion base on `BUILD_SHARED_LIBS` variable. `lua` and `luac` are also installed if built.