### PR TITLE
Correct LUA_LIBRARIES in cmake config

### DIFF
--- a/lua-5.4.5/CMakeLists.txt
+++ b/lua-5.4.5/CMakeLists.txt
@@ -35,6 +35,8 @@ set(LUA_LIB_SRCS
 
 set(TARGETS_TO_INSTALL lua_internal lua_include)
 
+set(LUA_LINKED_LIBRARIES)
+
 if(LUA_BUILD_AS_CXX)
 	set_source_files_properties(${LUA_LIB_SRCS} "src/lua.c" "src/luac.c" PROPERTIES LANGUAGE CXX )
 endif()
@@ -87,14 +89,17 @@ if(UNIX)
         if(NOT LIBM)
             message(FATAL_ERROR "libm not found and is required by lua")
         endif()
+        target_compile_definitions(lua_internal INTERFACE "LUA_USE_POSIX")
         target_link_libraries(lua_internal INTERFACE m)
-
-        target_compile_definitions(lua_internal 
-            INTERFACE LUA_USE_POSIX
-        )
+        list(APPEND LUA_LINKED_LIBRARIES m)
         if(LUA_SUPPORT_DL)
+            find_library(LIBDL "${CMAKE_DL_LIBS}")
+            if(NOT LIBDL)
+                message(FATAL_ERROR "libdl not found and is required by lua")
+            endif()
             target_compile_definitions(lua_internal INTERFACE "LUA_USE_DLOPEN")
-            target_link_libraries(lua_internal INTERFACE dl)
+            target_link_libraries(lua_internal INTERFACE "${CMAKE_DL_LIBS}")
+            list(APPEND LUA_LINKED_LIBRARIES "${CMAKE_DL_LIBS}")
         endif()
     endif()
 

--- a/lua-5.4.5/LuaConfig.cmake.in
+++ b/lua-5.4.5/LuaConfig.cmake.in
@@ -4,6 +4,17 @@ include("${CMAKE_CURRENT_LIST_DIR}/LuaTargets.cmake")
 
 set_and_check(LUA_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
 add_library(Lua::Library ALIAS "Lua::@LUA_EXPORT_LIBRARY@")
-set(LUA_LIBRARIES "Lua::Library")
+get_target_property(LUA_CONFIG "Lua::@LUA_EXPORT_LIBRARY@" IMPORTED_CONFIGURATIONS)
+get_target_property(LUA_LIBRARY "Lua::@LUA_EXPORT_LIBRARY@" "IMPORTED_LOCATION_${LUA_CONFIG}")
+set(LUA_LIBRARIES "${LUA_LIBRARY}")
+
+foreach(LIB_NAME @LUA_LINKED_LIBRARIES@)
+    find_library(LIB_LOCATION "${LIB_NAME}")
+    if(NOT LIB_LOCATION)
+        message(FATAL_ERROR "lib${LIB_NAME} not found and is required by lua")
+    else()
+        list(APPEND LUA_LIBRARIES "${LIB_LOCATION}")
+    endif()
+endforeach()
 
 check_required_components(Lua)


### PR DESCRIPTION
Currently (in 9fab0a4e31200d7a608ca6653738e35e129c16af), cmake variable `LUA_LIBRARIES` points to `Lua::lua_static` or `Lua::lua_shared` after including LuaConfig.cmake, but such value cannot be used when linking. As per cmake's own FindLua.cmake implementation (https://github.com/Kitware/CMake/blob/e2be23a2b39f4380f32fe65ba770addc154579c7/Modules/FindLua.cmake#L205-L231), `LUA_LIBRARY` points to the path of the actual library, and `LUA_LIBRARIES` contains path to `liblua` and its dependencies (`libm` and/or `libdl`).

This PR addresses above issue by tracking depnecy libraries with `LUA_LINKED_LIBRARIES` variable, then find those paths in LuaConfig.cmake.in. Produces LuaConfig.cmake like this:

```cmake
### @PACKATE_INIT@ ###

include("${CMAKE_CURRENT_LIST_DIR}/LuaTargets.cmake")

set_and_check(LUA_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
add_library(Lua::Library ALIAS "Lua::lua_static")
get_target_property(LUA_CONFIG "Lua::lua_static" IMPORTED_CONFIGURATIONS)
get_target_property(LUA_LIBRARY "Lua::lua_static" "IMPORTED_LOCATION_${LUA_CONFIG}")
set(LUA_LIBRARIES "${LUA_LIBRARY}")

foreach(LIB_NAME m;dl)
    find_library(LIB_LOCATION "${LIB_NAME}")
    if(NOT LIB_LOCATION)
        message(FATAL_ERROR "lib${LIB_NAME} not found and is required by lua")
    else()
        list(APPEND LUA_LIBRARIES "${LIB_LOCATION}")
    endif()
endforeach()

check_required_components(Lua)
```

setting `LUA_LIBRARY` and `LUA_LIBRARIES` makes it compatible to cmake's FindLua.cmake implementation.