### PR TITLE
Add test case for cmake module compatible mode

### DIFF
--- a/lua-config-package-tests/CMakeLists.txt
+++ b/lua-config-package-tests/CMakeLists.txt
@@ -12,3 +12,10 @@ target_link_libraries(lua-config-package-build-test-using-shared-target Lua::lua
 add_executable(lua-config-package-build-test-using-variables "./lua-config-package-build-test.c")
 target_link_libraries(lua-config-package-build-test-using-variables ${LUA_LIBRARIES})
 
+add_library(lua-lib-module-compatible-mode UNKNOWN IMPORTED ${LUA_LIBRARY})
+set_target_properties(lua-lib-module-compatible-mode PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${LUA_INCLUDE_DIR}
+        IMPORTED_LOCATION ${LUA_LIBRARY})
+
+add_executable(lua-config-package-build-test-using-module-compatible-mode "./lua-config-package-build-test.c")
+target_link_libraries(lua-config-package-build-test-using-module-compatible-mode lua-lib-module-compatible-mode)


### PR DESCRIPTION
See also #18.

Added test case for "module compatible mode" wihch produces variables same as cmake's own FindLua.cmake implementation (https://github.com/Kitware/CMake/blob/e2be23a2b39f4380f32fe65ba770addc154579c7/Modules/FindLua.cmake#L205-L231)

currently it won't pass but it would after #18 merged.