### PR TITLE
Introduce max policy version for compatibility with newer CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.12)
 project(lua LANGUAGES C VERSION 5.4.7)
 
 option(LUA_SUPPORT_DL "Support dynamic loading of compiled modules" OFF)


### PR DESCRIPTION
GitHub Actions is updating to CMake 4.0.0 on all their Ubuntu runner images. This version has removed support for versions before CMake 3.5. Any chance we could get the minimum required version raised to resolve the following error?

```
CMake Error at build/_deps/lua-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```