### PR TITLE
Let normal variables take precedence over `option()`-declared variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.1...3.12)
+cmake_policy(SET CMP0077 NEW)
 project(lua LANGUAGES C VERSION 5.4.7)
 
 option(LUA_SUPPORT_DL "Support dynamic loading of compiled modules" OFF)


### PR DESCRIPTION
This sets the CMake Policy 0077 to `NEW` behavior, allowing existing normal variables to not be overridden by `option()` calls. I would like to have this; otherwise older versions of CMake build the Lua compiler/standalone interpreter when I explicitly tell it not to with `set(LUA_BUILD_BINARY OFF)` and `set(LUA_BUILD_COMPILER OFF)`.

An example from the GitHub Actions `ubuntu-latest` runner:
<img width="658" height="414" alt="image" src="https://github.com/user-attachments/assets/f88b2414-1cac-47b2-9dfe-0b45a04cf2b4" />
<img width="649" height="21" alt="image" src="https://github.com/user-attachments/assets/6f66338d-9749-4704-97e0-b7cd7c2e96ef" />

(I don't want this building since it's being built for a platform it'll never run on...)